### PR TITLE
Updated value of max tokens for gemini 2.5 to correct one

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -748,7 +748,7 @@ export type GeminiModelId = keyof typeof geminiModels
 export const geminiDefaultModelId: GeminiModelId = "gemini-2.0-flash-001"
 export const geminiModels = {
 	"gemini-2.5-pro-exp-03-25": {
-		maxTokens: 8192,
+		maxTokens: 65_536,
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		supportsPromptCache: false,


### PR DESCRIPTION
## Context

Updated value of max token value for recently release gemini 2.5 pro 03-25

## Implementation


## Note
[Official documentation](https://ai.google.dev/gemini-api/docs/models#token-size) states that token limit is 64k but actual implementation on Google AI Studio uses 65536 as max output token limit

